### PR TITLE
Replace crates extension with Dependi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [1.2.0] - 2025-01-17
+
+### Changed
+
+- Replaced the deprecated crates extension with Dependi
+
 ## [1.1.1] - 2023-09-12
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ By installing Rust Extension Pack, the following extensions are installed:
   - Code completion
   - Imports insertion
   - Semantic syntax highlighting
-- [📦 crates](https://github.com/serayuzgur/crates)
-  - Display the latest version of the crate next to it
-  - Show all versions (clickable) on the tooltip of the crate hovered.
+- [📦 Dependi](https://github.com/filllabs/dependi)
+  - Manage Versions: Dependi provides clear and concise views of all your project dependencies, making it easy to manage updates and versions.
+  - Related Links: For more insights and resources related to the languages and tools Dependi supports
+  - Vulnerabilities at a Glance: Quickly identify vulnerabilities in your project dependencies and take action to mitigate risks.
+  - Vulnerability Reports: Generate comprehensive reports detailing the vulnerabilities in your dependencies, helping you maintain secure codebases.
 - [📦 Even Better TOML](https://github.com/tamasfe/taplo)
   - TOML 1.0.0 support
   - Syntax highlighting

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     },
     "extensionPack": [
         "rust-lang.rust-analyzer",
-        "serayuzgur.crates",
+        "fill-labs.dependi",
         "tamasfe.even-better-toml",
         "jscearcy.rust-doc-viewer",
         "panicbit.cargo",


### PR DESCRIPTION
Fixes #9

Replace the deprecated 📦 crates extension with 📦 Dependi in the Rust Extension Pack.

* **package.json**
  - Replace `serayuzgur.crates` with `fill-labs.dependi` in the `extensionPack` array.

* **README.md**
  - Replace the 📦 crates extension with 📦 Dependi in the "Included extensions" section.
  - Update the description of the 📦 Dependi extension with its features.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Zerotask/vscode-rust-extension-pack/pull/10?shareId=88ec25a0-7622-4002-af0a-9e4acbc6ff69).